### PR TITLE
[logos] %property rewrite.

### DIFF
--- a/bin/lib/Logos/Generator/Base/Property.pm
+++ b/bin/lib/Logos/Generator/Base/Property.pm
@@ -2,274 +2,74 @@ package Logos::Generator::Base::Property;
 use strict;
 use Logos::Util;
 
-sub key {
+sub getterName {
 	my $self = shift;
 	my $property = shift;
-
-	my $build = "_logos_property_key\$" . $property->group . "\$" . $property->class . "\$" . $property->name;
-
-	return $build;
+	return Logos::sigil("method").$property->group."\$".$property->class."\$".$property->getter;
 }
 
-sub getter {
+sub setterName {
 	my $self = shift;
 	my $property = shift;
-	my $name = shift;
-	my $key = shift;
-	my $type = $property->type;
-
-	$type =~ s/\s+$//;
-
-	if(!$name){
-		# Use property name if no getter specified
-		$name = $property->name;
-	}
-
-	# Build function start
-	my $build = "__attribute__((used)) "; # If the property is never accessed, clang's optimizer will remove the getter/setter if this attribute isn't specified
-
-	$build .= "static " . $type . " _logos_method\$" . $property->group . "\$" . $property->class . "\$" . $name . "\$" . "(" . $property->class . "* __unused self, SEL __unused _cmd){";
-
-	# Build function body
-
-	$build .= " return ";
-
-
-	if ($type =~ /^(BOOL|(unsigned )?char|double|float|CGFloat|(unsigned )?int|NSInteger|unsigned|NSUInteger|(unsigned )?long (long)?|(unsigned )?short|NSRange|CGPoint|CGVector|CGSize|CGRect|CGAffineTransform|UIEdgeInsets|UIOffset|CATransform3D|CMTime(Range|Mapping)?|MKCoordinate(Span)?|SCNVector[34]|SCNMatrix4)$/){
-		$build .= "[";
-	}
-
-	$build .= "objc_getAssociatedObject(self, &" . $key . ")";
-
-	if ($type eq "BOOL"){
-		$build .= " boolValue]";
-	} elsif ($type eq "char"){
-		$build .= " charValue]";
-	} elsif ($type eq "unsigned char"){
-		$build .= " unsignedCharValue]";
-	} elsif ($type eq "double"){
-		$build .= " doubleValue]";
-	} elsif ($type =~ /^(float|CGFloat)$/){
-		$build .= " floatValue]";
-	} elsif ($type eq "int"){
-		$build .= " intValue]";
-	} elsif ($type eq "NSInteger"){
-		$build .= " integerValue]";
-	} elsif ($type =~ /^unsigned( int)?$/){
-		$build .= " unsignedIntValue]";
-	} elsif ($type eq "NSUInteger"){
-		$build .= " unsignedIntegerValue]";
-	} elsif ($type eq "long"){
-		$build .= " longValue]";
-	} elsif ($type eq "unsigned long"){
-		$build .= " unsignedLongValue]";
-	} elsif ($type eq "long long"){
-		$build .= " longLongValue]";
-	} elsif ($type eq "unsigned long long"){
-		$build .= " unsignedLongLongValue]";
-	} elsif ($type eq "short"){
-		$build .= " shortValue]";
-	} elsif ($type eq "unsigned short"){
-		$build .= " unsignedShortValue]";
-	} elsif ($type =~ /^(NSRange|CGPoint|CGVector|CGSize|CGRect|CGAffineTransform|UIEdgeInsets|UIOffset|CATransform3D|CMTime(Range|Mapping)?|MKCoordinate(Span)?|SCNVector[34]|SCNMatrix4)$/){
-		$build .= " " . $type . "Value]";
-	}
-
-	$build .= "; }";
-
-	return $build;
+	return Logos::sigil("method").$property->group."\$".$property->class."\$".$property->setter;
 }
 
-sub setter {
+sub definition {
 	my $self = shift;
 	my $property = shift;
-	my $name = shift;
-	my $policy = shift;
-	my $key = shift;
-	my $type = $property->type;
 
-	$type =~ s/\s+$//;
+	my $propertyType = $property->type;
+	my $propertyClass = $property->class;
+	my $propertyGetter = $property->getter;
+	my $propertyGetterName = $self->getterName($property);
+	my $propertySetter = $property->setter;
+	my $propertySetterName = $self->setterName($property);
+	my $propertyAssociationPolicy = $property->associationPolicy;
+	my $wrapValue = !($propertyAssociationPolicy =~ /RETAIN|COPY/);
 
-	if(!$name){
-		# Capitalize first letter
-		$_ = $property->name;
-		$_ =~ s/^([a-z])/\u$1/;
-
-		$name = "set" . $_;
-	}
-
-	# Remove semicolon
-	$name =~ s/://;
-
-	# Build function start
-
-	my $build = "__attribute__((used)) "; # If the property is never accessed, clang's optimizer will remove the getter/setter if this attribute isn't specified
-	$build .= "static void _logos_method\$" . $property->group . "\$" . $property->class . "\$" . $name . "\$" . "(" . $property->class . "* __unused self, SEL __unused _cmd, " . $type . " arg){ ";
-
-	# Build function body
-
-	$build .= "objc_setAssociatedObject(self, &" . $key . ", ";
-
-	my $hasOpening = 1;
-
-	if ($type eq "BOOL"){
-		$build .= "[NSNumber numberWithBool:";
-	} elsif ($type eq "char"){
-		$build .= "[NSNumber numberWithChar:";
-	} elsif ($type eq "unsigned char"){
-		$build .= "[NSNumber numberWithUnsignedChar:";
-	} elsif ($type eq "double"){
-		$build .= "[NSNumber numberWithDouble:";
-	} elsif ($type =~ /^(float|CGFloat)$/){
-		$build .= "[NSNumber numberWithFloat:";
-	} elsif ($type eq "int"){
-		$build .= "[NSNumber numberWithInt:";
-	} elsif ($type eq "NSInteger"){
-		$build .= "[NSNumber numberWithInteger:";
-	} elsif ($type =~ /^unsigned( int)?$/){
-		$build .= "[NSNumber numberWithUnsignedInt:";
-	} elsif ($type eq "NSUInteger"){
-		$build .= "[NSNumber numberWithUnsignedInteger:";
-	} elsif ($type eq "long"){
-		$build .= "[NSNumber numberWithLong:";
-	} elsif ($type eq "unsigned long"){
-		$build .= "[NSNumber numberWithUnsignedLong:";
-	} elsif ($type eq "long long"){
-		$build .= "[NSNumber numberWithLongLong:";
-	} elsif ($type eq "unsigned long long"){
-		$build .= "[NSNumber numberWithUnsignedLongLong:";
-	} elsif ($type eq "short"){
-		$build .= "[NSNumber numberWithShort:";
-	} elsif ($type eq "unsigned short"){
-		$build .= "[NSNumber numberWithUnsignedShort:";
-	} elsif ($type =~ /^(NSRange|CGPoint|CGVector|CGSize|CGRect|CGAffineTransform|UIEdgeInsets|UIOffset|CATransform3D|CMTime(Range|Mapping)?|MKCoordinate(Span)?|SCNVector[34]|SCNMatrix4)$/){
-		$build .= "[NSValue valueWith" . $type . ":";
+	# Build getter
+	my $getter_func = "__attribute__((used)) "; # If the property is never accessed, clang's optimizer will remove the getter/setter if this attribute isn't specified
+	$getter_func .= "static $propertyType $propertyGetterName($propertyClass * __unused self, SEL __unused _cmd) ";
+	if($wrapValue) {
+		$getter_func .= "{ NSValue * value = objc_getAssociatedObject(self, $propertyGetterName); $propertyType rawValue; [value getValue:&rawValue]; return rawValue; }";
 	} else {
-		$hasOpening = 0;
+		$getter_func .= "{ return ($propertyType)objc_getAssociatedObject(self, $propertyGetterName); }";
 	}
 
-	$build .= "arg";
-
-	if ($hasOpening){
-		$build .= "]";
+	# Build setter
+	my $setter_func = "__attribute__((used)) "; # If the property is never accessed, clang's optimizer will remove the getter/setter if this attribute isn't specified
+	$setter_func .= "static void $propertySetterName($propertyClass * __unused self, SEL __unused _cmd, $propertyType rawValue) ";
+	if($wrapValue) {
+		$setter_func .= "{ NSValue * value = [NSValue valueWithBytes:&rawValue objCType:\@encode($propertyType)]; objc_setAssociatedObject(self, $propertyGetterName, value, OBJC_ASSOCIATION_RETAIN_NONATOMIC); }";
+	} else {
+		$setter_func .= "{ objc_setAssociatedObject(self, $propertyGetterName, rawValue, $propertyAssociationPolicy); }";
 	}
 
-	$build .= ", ".$policy.")";
-
-	$build .= "; }";
-
-	return $build;
-}
-
-sub getters_setters {
-	my $self = shift;
-	my $property = shift;
-
-	my ($assign, $retain, $nonatomic, $copy, $getter, $setter);
-
-
-	for(my $i = 0; $i < $property->numattr; $i++){
-
-		my $attr = $property->attributes->[$i];
-
-		if($attr =~ /assign/){
-			$assign = 1;
-		}elsif($attr =~ /retain/){
-			$retain = 1;
-		}elsif($attr =~ /nonatomic/){
-			$nonatomic = 1;
-		}elsif($attr =~ /copy/){
-			$copy = 1;
-		}elsif($attr =~ /getter=(\w+)/){
-			$getter = $1;
-		}elsif($attr =~ /setter=(\w+:)/){
-			$setter = $1;
-		}
-	}
-
-	my $policy = "OBJC_ASSOCIATION_";
-
-	if($retain){
-		$policy .= "RETAIN";
-	}elsif($copy){
-		$policy .= "COPY";
-	}elsif($assign){
-		$policy .= "ASSIGN";
-	}else{
-		print "error: no 'assign', 'retain', or 'copy' attribu...wait, how did you manage to get here?\n";
-	}
-
-	if($nonatomic){
-		# The 'assign' attribute appears to be nonatomic by default.
-		if(!$assign){
-			$policy .= "_NONATOMIC";
-		}
-	}
-
-	$property->associationPolicy($policy);
-
-	my $build;
-
-	my $key = $self->key($property);
-	my $getter_func = $self->getter($property, $getter, $key);
-	my $setter_func = $self->setter($property, $setter, $policy, $key);
-
-	$build .= $build . "static char " . $key . ";";
-	$build .= $getter_func;
-	$build .= $setter_func;
-
-
-	return $build;
+	return "$getter_func; $setter_func";
 }
 
 sub initializers {
 	my $self = shift;
 	my $property = shift;
 
-	my ($getter, $setter);
+	my $className = Logos::sigil("class").$property->group."\$".$property->class;
+	my $propertyType = $property->type;
+	my $propertyGetter = $property->getter;
+	my $propertyGetterName = $self->getterName($property);
+	my $propertySetter = $property->setter;
+	my $propertySetterName = $self->setterName($property);
 
-	for(my $i = 0; $i < $property->numattr; $i++){ # This could be more efficient
-		my $attr = $property->attributes->[$i];
-
-		if($attr =~ /getter=(\w+)/){
-			$getter = $1;
-		}elsif($attr =~ /setter=(\w+:)/){
-			$setter = $1;
-			$setter =~ s/://;
-		}
-	}
-
-	if(!$setter){
-		# Capitalize first letter
-		$_ = $property->name;
-		$_ =~ s/^([a-z])/\u$1/;
-
-		$setter = "set" . $_;
-	}
-
-	if(!$getter){
-		# Use property name if no getter specified
-		$getter = $property->name;
-	}
-
-
-	my $build = "";
-
-	$build .= "{ ";
+	my $build = "{ char _typeEncoding[1024];";
 
 	# Getter
-	$build .= "class_addMethod(";
-
-	$build .= "_logos_class\$" . $property->group . "\$" . $property->class . ", ";
-	$build .= "\@selector(" . $getter . "), " . "(IMP)&" . "_logos_method\$" . $property->group . "\$" . $property->class . "\$" . $getter . "\$, [[NSString stringWithFormat:\@\"%s\@:\", \@encode(".$property->type.")] UTF8String]);";
+	$build .= " sprintf(_typeEncoding, \"%s\@:\", \@encode($propertyType));";
+	$build .= " class_addMethod($className, \@selector($propertyGetter), (IMP)&$propertyGetterName, _typeEncoding);";
 
 	# Setter
-	$build .= "class_addMethod(";
-	$build .= "_logos_class\$" . $property->group . "\$" . $property->class . ", ";
+	$build .= " sprintf(_typeEncoding, \"v\@:%s\", \@encode($propertyType));";
+	$build .= " class_addMethod($className, \@selector($propertySetter:), (IMP)&$propertySetterName, _typeEncoding);";
 
-	$build .= "\@selector(" . $setter . ":), " . "(IMP)&" . "_logos_method\$" . $property->group . "\$" . $property->class . "\$" . $setter . "\$, [[NSString stringWithFormat:\@\"v\@:%s\", \@encode(".$property->type.")] UTF8String]);";
-
-	$build .= "} ";
+	$build .= " } ";
 
 	return $build;
 }

--- a/bin/lib/Logos/Property.pm
+++ b/bin/lib/Logos/Property.pm
@@ -5,7 +5,7 @@ use strict;
 # Setters and Getters #
 # #####################
 
-sub new{
+sub new {
 	my $proto = shift;
 	my $class = ref($proto) || $proto;
 	my $self = {};
@@ -13,9 +13,9 @@ sub new{
 	$self->{GROUP} = undef;
 	$self->{NAME} = undef;
 	$self->{TYPE} = undef;
-	$self->{NUMATTR} = undef;
 	$self->{ASSOCIATIONPOLICY} = undef;
-	$self->{ATTRIBUTES} = [];
+	$self->{GETTER} = undef;
+	$self->{SETTER} = undef;
 	bless($self, $class);
 	return $self;
 }
@@ -44,22 +44,22 @@ sub type {
 	return $self->{TYPE};
 }
 
-sub numattr {
-	my $self = shift;
-	if(@_) { $self->{NUMATTR} = shift; }
-	return $self->{NUMATTR};
-}
-
-sub attributes {
-	my $self = shift;
-	if(@_) { @{$self->{ATTRIBUTES}} = @_; }
-	return $self->{ATTRIBUTES};
-}
-
 sub associationPolicy {
 	my $self = shift;
-	if (@_) { $self->{ASSOCIATIONPOLICY} = shift; }
+	if(@_) { $self->{ASSOCIATIONPOLICY} = shift; }
 	return $self->{ASSOCIATIONPOLICY};
+}
+
+sub getter {
+	my $self = shift;
+	if(@_) { $self->{GETTER} = shift; }
+	return $self->{GETTER};
+}
+
+sub setter {
+	my $self = shift;
+	if(@_) { $self->{SETTER} = shift; }
+	return $self->{SETTER};
 }
 
 ##### #

--- a/bin/logos.pl
+++ b/bin/logos.pl
@@ -4,7 +4,7 @@ use 5.006;
 use warnings;
 use strict;
 use FindBin;
-use lib "$FindBin::Bin/lib";
+use lib "$FindBin::RealBin/lib";
 use Digest::MD5 'md5_hex';
 use Module::Load;
 use Module::Load::Conditional 'can_load';

--- a/bin/logos.pl
+++ b/bin/logos.pl
@@ -4,7 +4,7 @@ use 5.006;
 use warnings;
 use strict;
 use FindBin;
-use lib "$FindBin::RealBin/lib";
+use lib "$FindBin::Bin/lib";
 use Digest::MD5 'md5_hex';
 use Module::Load;
 use Module::Load::Conditional 'can_load';
@@ -570,64 +570,93 @@ foreach my $line (@lines) {
 
 			# check property attribute validity
 			my @attributes = split/\(?\s*,\s*\)?/, $1;
+			my $type = $2;
+			my $name = $3;
 			my ($assign, $retain, $copy, $nonatomic, $getter, $setter);
 			my $numattr = 0;
 
-			foreach(@attributes){
-				$numattr++;
-
-				if($_ =~ /assign/){
-					$assign = 1;
-				}elsif($_ =~ /retain/){
-					$retain = 1;
-				}elsif($_ =~ /copy/){
-					$copy = 1;
-				}elsif($_ =~ /nonatomic/){
-					$nonatomic = 1;
-				}elsif($_ =~ /getter=(\w+)/){
+			foreach(@attributes) {
+				if($_ =~ /getter=(\w+)/) {
 					$getter = $1;
-				}elsif($_ =~ /setter=(\w+:)/){
+				} elsif($_ =~ /setter=(\w+:)/) {
 					$setter = $1;
-				}elsif($_ =~ /readwrite|readonly/){
+				} elsif($_ eq "assign" || $_ eq "unsafe_unretained") {
+					$assign = 1;
+				} elsif($_ eq "retain" || $_ eq "strong") {
+					$retain = 1;
+				} elsif($_ eq "copy") {
+					$copy = 1;
+				} elsif($_ eq "nonatomic") {
+					$nonatomic = 1;
+				} elsif($_ =~ /readwrite|readonly|weak/) {
 					fileError($lineno, "property attribute '".$_."' not supported.");
-				}else{
+				} else {
 					fileError($lineno, "unknown property attribute '".$_."'.");
 				}
 			}
 
-			if(!$assign && !$retain && !$copy){
-				fileWarning($lineno, "no 'assign', 'retain', or 'copy' attribute is specified - 'assign' is assumed");
-				push(@attributes, "assign");
-				$numattr++;
-			}
-
-			if($assign && $retain){
+			if($assign && $retain) {
 				fileError($lineno, "property attributes 'assign' and 'retain' are mutually exclusive.");
 			}
 
-			if($assign && $copy){
+			if($assign && $copy) {
 				fileError($lineno, "property attributes 'assign' and 'copy' are mutually exclusive.");
 			}
 
-			if($copy && $retain){
+			if($copy && $retain) {
 				fileError($lineno, "property attributes 'copy' and 'retain' are mutually exclusive.");
 			}
 
 			my $property = Property->new();
-
-
 			$property->class($currentClass->name);
+			$property->type($type);
+			$property->name($name);
 
-			if($currentGroup){
+			if(!$assign && !$retain && !$copy) {
+				fileWarning($lineno, "no 'assign', 'retain', or 'copy' attribute is specified - 'assign' is assumed");
+				$assign = 1;
+			}
+
+			my $policy = "OBJC_ASSOCIATION_";
+			if($retain) {
+				$policy .= "RETAIN";
+			} elsif($copy) {
+				$policy .= "COPY";
+			} elsif($assign) {
+				$policy .= "ASSIGN";
+			} else {
+				fileError($lineno, "error: no 'assign', 'retain', or 'copy' attribu...wait, how did you manage to get here?\n");
+			}
+
+			if($nonatomic) {
+				# The 'assign' attribute appears to be nonatomic by default.
+				if(!$assign) {
+					$policy .= "_NONATOMIC";
+				}
+			}
+
+			$property->associationPolicy($policy);
+
+			if($currentGroup) {
 				$property->group($currentGroup->name);
-			}else{
+			} else {
 				$property->group("_ungrouped");
 			}
 
-			$property->numattr($numattr);
-			$property->attributes(@attributes);
-			$property->type($2);
-			$property->name($3);
+			if(!$getter) {
+				# Use property name if no getter specified
+				$getter = $name;
+			}
+			$property->getter($getter);
+
+			if(!$setter) {
+				# Capitalize first letter
+				$_ = $name;
+				$_ =~ s/://;
+				$_ =~ s/^([a-z])/\u$1/;
+				$setter = "set".$_;
+			}
+			$property->setter($setter);
 
 			$currentClass->addProperty($property);
 
@@ -635,7 +664,7 @@ foreach my $line (@lines) {
 			my $patch = Patch->new();
 			$patch->line($lineno);
 			$patch->range($patchStart, pos($line));
-			$patch->source(Patch::Source::Generator->new($property, 'getters_setters'));
+			$patch->source(Patch::Source::Generator->new($property, 'definition'));
 			addPatch($patch);
 		} elsif($line =~ /\G%hookf\b/gc) {
 			#%hookf


### PR DESCRIPTION
Fixes issue #243 by storing objects directly or boxing them in NSValue
objects.
Parse syntax once.
Change Logos::Generator::Base::Property sub names to align with existing
names.
Improve attribute checks by replacing regex for equality comparisons to
reduce false positives.