### PR TITLE
Reduce code duplication on symbol name generation.

### DIFF
--- a/bin/lib/Logos/Generator/Base/Class.pm
+++ b/bin/lib/Logos/Generator/Base/Class.pm
@@ -16,17 +16,23 @@ sub _metaInitExpression {
 	return "object_getClass(".$self->variable($class).")";
 }
 
+sub _symbolName {
+	my $self = shift;
+	my $tag = shift;
+	my $class = shift;
+	return Logos::sigil($tag, $class->group->name, $class->name);
+}
 
 sub variable {
 	my $self = shift;
 	my $class = shift;
-	return Logos::sigil("class").$class->group->name."\$".$class->name;
+	return $self->_symbolName("class", $class);
 }
 
 sub metaVariable {
 	my $self = shift;
 	my $class = shift;
-	return Logos::sigil("metaclass").$class->group->name."\$".$class->name;
+	return $self->_symbolName("metaclass", $class);
 }
 
 sub declarations {

--- a/bin/lib/Logos/Generator/Base/Function.pm
+++ b/bin/lib/Logos/Generator/Base/Function.pm
@@ -7,25 +7,32 @@ sub _initExpression {
 	my $self = shift;
 	my $function = shift;
 	return $function->expression if $function->expression;
-	return $function->name
+	return "(void *)".$function->name;
+}
+
+sub _symbolName {
+	my $self = shift;
+	my $tag = shift;
+	my $function = shift;
+	return Logos::sigil($tag, $function->group->name, $function->name);
 }
 
 sub variable {
 	my $self = shift;
 	my $function = shift;
-	return Logos::sigil("symbol").$function->group->name."\$".$function->name;
+	return $self->_symbolName("symbol", $function);
 }
 
 sub originalFunctionName {
 	my $self = shift;
 	my $function = shift;
-	return Logos::sigil("orig").$function->group->name."\$".$function->name;
+	return $self->_symbolName("orig", $function);
 }
 
 sub newFunctionName {
 	my $self = shift;
 	my $function = shift;
-	return Logos::sigil("function").$function->group->name."\$".$function->name;
+	return $self->_symbolName("function", $function);
 }
 
 sub originalFunctionCall {

--- a/bin/lib/Logos/Generator/Base/Generator.pm
+++ b/bin/lib/Logos/Generator/Base/Generator.pm
@@ -47,8 +47,8 @@ sub classReferenceWithScope {
 	my $self = shift;
 	my $classname = shift;
 	my $scope = shift;
-	my $prefix = Logos::sigil($scope eq "+" ? "static_metaclass_lookup" : "static_class_lookup");
-	return $prefix.$classname."()";
+	my $prefix = Logos::sigil($scope eq "+" ? "static_metaclass_lookup" : "static_class_lookup", $classname);
+	return $prefix."()";
 }
 
 1;

--- a/bin/lib/Logos/Generator/Base/Method.pm
+++ b/bin/lib/Logos/Generator/Base/Method.pm
@@ -2,16 +2,25 @@ package Logos::Generator::Base::Method;
 use strict;
 use Logos::Util;
 
+sub _symbolName {
+	my $self = shift;
+	my $tag = shift;
+	my $method = shift;
+
+	my $scopeTag = ($method->scope eq "+" ? "meta_" : "").$tag;
+	return Logos::sigil($scopeTag, $method->class->group->name, $method->class->name, $method->_new_selector);
+}
+
 sub originalFunctionName {
 	my $self = shift;
 	my $method = shift;
-	return Logos::sigil(($method->scope eq "+" ? "meta_" : "")."orig").$method->groupIdentifier."\$".$method->class->name."\$".$method->_new_selector;
+	return $self->_symbolName("orig", $method);
 }
 
 sub newFunctionName {
 	my $self = shift;
 	my $method = shift;
-	return Logos::sigil(($method->scope eq "+" ? "meta_" : "")."method").$method->groupIdentifier."\$".$method->class->name."\$".$method->_new_selector;
+	return $self->_symbolName("method", $method);
 }
 
 sub definition {

--- a/bin/lib/Logos/Generator/Base/Property.pm
+++ b/bin/lib/Logos/Generator/Base/Property.pm
@@ -5,13 +5,13 @@ use Logos::Util;
 sub getterName {
 	my $self = shift;
 	my $property = shift;
-	return Logos::sigil("method").$property->group."\$".$property->class."\$".$property->getter;
+	return Logos::sigil("method", $property->group->name, $property->class->name, $property->getter);
 }
 
 sub setterName {
 	my $self = shift;
 	my $property = shift;
-	return Logos::sigil("method").$property->group."\$".$property->class."\$".$property->setter;
+	return Logos::sigil("method", $property->group->name, $property->class->name, $property->setter);
 }
 
 sub definition {
@@ -19,7 +19,7 @@ sub definition {
 	my $property = shift;
 
 	my $propertyType = $property->type;
-	my $propertyClass = $property->class;
+	my $propertyClass = $property->class->name;
 	my $propertyGetter = $property->getter;
 	my $propertyGetterName = $self->getterName($property);
 	my $propertySetter = $property->setter;
@@ -52,7 +52,7 @@ sub initializers {
 	my $self = shift;
 	my $property = shift;
 
-	my $className = Logos::sigil("class").$property->group."\$".$property->class;
+	my $className = Logos::sigil("class", $property->group->name, $property->class->name);
 	my $propertyType = $property->type;
 	my $propertyGetter = $property->getter;
 	my $propertyGetterName = $self->getterName($property);

--- a/bin/lib/Logos/Generator/Base/StaticClassGroup.pm
+++ b/bin/lib/Logos/Generator/Base/StaticClassGroup.pm
@@ -6,7 +6,7 @@ sub _methodForClassWithScope {
 	my $class = shift;
 	my $scope = shift;
 	my $return = "";
-	my $methodname = Logos::sigil($scope eq "+" ? "static_metaclass_lookup" : "static_class_lookup").$class;
+	my $methodname = Logos::sigil($scope eq "+" ? "static_metaclass_lookup" : "static_class_lookup", $class);
 	my $lookupMethod = $scope eq "+" ? "objc_getMetaClass" : "objc_getClass";
 
 	# This is a dirty assumption - we believe that we will always be using a compiler that defines __GNUC__ and respects GNU C attributes.

--- a/bin/lib/Logos/Generator/internal/Class.pm
+++ b/bin/lib/Logos/Generator/internal/Class.pm
@@ -5,13 +5,13 @@ use parent qw(Logos::Generator::Base::Class);
 sub superVariable {
 	my $self = shift;
 	my $class = shift;
-	return Logos::sigil("superclass").$class->group->name."\$".$class->name;
+	return Logos::sigil("superclass", $class->group->name, $class->name);
 }
 
 sub superMetaVariable {
 	my $self = shift;
 	my $class = shift;
-	return Logos::sigil("supermetaclass").$class->group->name."\$".$class->name;
+	return Logos::sigil("supermetaclass", $class->group->name, $class->name);
 }
 
 sub declarations {

--- a/bin/lib/Logos/Group.pm
+++ b/bin/lib/Logos/Group.pm
@@ -47,11 +47,6 @@ sub initRequired {
 	return 0;
 }
 
-sub identifier {
-	my $self = shift;
-	return main::sanitize($self->{NAME});
-}
-
 sub initLine {
 	my $self = shift;
 	if(@_) { $self->{INITLINE} = shift; }

--- a/bin/lib/Logos/Method.pm
+++ b/bin/lib/Logos/Method.pm
@@ -39,11 +39,6 @@ sub return {
 	return $self->{RETURN};
 }
 
-sub groupIdentifier {
-	my $self = shift;
-	return $self->class->group->identifier;
-}
-
 sub selectorParts {
 	my $self = shift;
 	if(@_) { @{$self->{SELECTOR_PARTS}} = @_; }

--- a/bin/logos.pl
+++ b/bin/logos.pl
@@ -11,7 +11,7 @@ use Module::Load::Conditional 'can_load';
 use Getopt::Long;
 
 package Logos;
-sub sigil { my $id = shift; return "_logos_$id\$"; }
+sub sigil { $_[0] = "_logos_".$_[0]; return join("\$", @_); }
 package main;
 
 use Logos::Util;
@@ -622,7 +622,7 @@ foreach my $line (@lines) {
 			}
 
 			my $property = Property->new();
-			$property->class($currentClass->name);
+			$property->class($currentClass);
 			$property->type($type);
 			$property->name($name);
 
@@ -652,9 +652,9 @@ foreach my $line (@lines) {
 			$property->associationPolicy($policy);
 
 			if($currentGroup) {
-				$property->group($currentGroup->name);
+				$property->group($currentGroup);
 			} else {
-				$property->group("_ungrouped");
+				$property->group($defaultGroup);
 			}
 
 			if(!$getter) {


### PR DESCRIPTION
- Reimplemented sigil to take a list of arguments and join them with "$".
- Removed group identifier property which wasn't congruent with the %group regex match.
- Corrected %property to use the objects instead of their names (for group and class).
- Added `void *` cast to %hookf init expression.