### PR TITLE
%property overhaul

### DIFF
--- a/bin/lib/Logos/Class.pm
+++ b/bin/lib/Logos/Class.pm
@@ -25,12 +25,15 @@ sub new {
 ##################### #
 # Setters and Getters #
 # #####################
+
+# Such as 'UIView'
 sub name {
 	my $self = shift;
 	if(@_) { $self->{NAME} = shift; }
 	return $self->{NAME};
 }
 
+# Such as a call to objc_getClass
 sub expression {
 	my $self = shift;
 	if(@_) {
@@ -50,6 +53,7 @@ sub metaexpression {
 	return $self->{METAEXPR};
 }
 
+# Such as 'UIView *'
 sub type {
 	my $self = shift;
 	if(@_) { $self->{TYPE} = shift; }

--- a/bin/lib/Logos/Generator/Base/Class.pm
+++ b/bin/lib/Logos/Generator/Base/Class.pm
@@ -49,10 +49,10 @@ sub initializers {
 	my $self = shift;
 	my $class = shift;
 	my $return = "";
-	for(@{$class->methods}) {
+	for(@{$class->properties}) {
 		$return .= Logos::Generator::for($_)->initializers;
 	}
-	for(@{$class->properties}) {
+	for(@{$class->methods}) {
 		$return .= Logos::Generator::for($_)->initializers;
 	}
 	return $return;

--- a/bin/lib/Logos/Generator/Base/Property.pm
+++ b/bin/lib/Logos/Generator/Base/Property.pm
@@ -14,10 +14,24 @@ sub setterName {
 	return Logos::sigil("property", $property->group->name, $property->class->name, $property->setter);
 }
 
+# addAttribute(attributeList, attributeCount, attributeName, attributeValue)
+#
+# attributeName is one of the property attribute characters, it will be "stringified" for you
+# attribute value must be a variable or something else; it will NOT be "stringified" for you; omit it to use ""
+sub addAttribute {
+	my $self = shift;
+	my $attrList = shift;
+	my $counter = shift;
+	my $name = shift;
+	my $value = shift // "\"\"";
+	return " $attrList [$counter++] = (objc_property_attribute_t) { \"$name\", $value };";
+}
+
 sub definition {
 	my $self = shift;
 	my $property = shift;
 
+	my $readonly = $property->readonly;
 	my $propertyType = $property->type;
 	my $propertyClass = $property->class->name;
 	my $propertyGetter = $property->getter;
@@ -27,47 +41,89 @@ sub definition {
 	my $propertyAssociationPolicy = $property->associationPolicy;
 	my $wrapValue = !($propertyAssociationPolicy =~ /RETAIN|COPY/);
 
-	# Build getter
-	my $getter_func = "__attribute__((used)) "; # If the property is never accessed, clang's optimizer will remove the getter/setter if this attribute isn't specified
-	$getter_func .= "static $propertyType $propertyGetterName($propertyClass * __unused self, SEL __unused _cmd) ";
-	if($wrapValue) {
-		$getter_func .= "{ NSValue * value = objc_getAssociatedObject(self, (void *)$propertyGetterName); $propertyType rawValue; [value getValue:&rawValue]; return rawValue; }";
-	} else {
-		$getter_func .= "{ return ($propertyType)objc_getAssociatedObject(self, (void *)$propertyGetterName); }";
+	if (!$readonly) {
+		# Build getter
+		my $getter_func = "__attribute__((used)) "; # If the property is never accessed, clang's optimizer will remove the getter/setter if this attribute isn't specified
+		$getter_func .= "static $propertyType $propertyGetterName($propertyClass * __unused self, SEL __unused _cmd) ";
+		if($wrapValue) {
+			$getter_func .= "{ NSValue * value = objc_getAssociatedObject(self, (void *)$propertyGetterName); $propertyType rawValue; [value getValue:&rawValue]; return rawValue; }";
+		} else {
+			$getter_func .= "{ return ($propertyType)objc_getAssociatedObject(self, (void *)$propertyGetterName); }";
+		}
+
+		# Build setter
+		my $setter_func = "__attribute__((used)) "; # If the property is never accessed, clang's optimizer will remove the getter/setter if this attribute isn't specified
+		$setter_func .= "static void $propertySetterName($propertyClass * __unused self, SEL __unused _cmd, $propertyType rawValue) ";
+		if($wrapValue) {
+			$setter_func .= "{ NSValue * value = [NSValue valueWithBytes:&rawValue objCType:\@encode($propertyType)]; objc_setAssociatedObject(self, (void *)$propertyGetterName, value, OBJC_ASSOCIATION_RETAIN_NONATOMIC); }";
+		} else {
+			$setter_func .= "{ objc_setAssociatedObject(self, (void *)$propertyGetterName, rawValue, $propertyAssociationPolicy); }";
+		}
+
+		return "$getter_func;\n$setter_func";
 	}
 
-	# Build setter
-	my $setter_func = "__attribute__((used)) "; # If the property is never accessed, clang's optimizer will remove the getter/setter if this attribute isn't specified
-	$setter_func .= "static void $propertySetterName($propertyClass * __unused self, SEL __unused _cmd, $propertyType rawValue) ";
-	if($wrapValue) {
-		$setter_func .= "{ NSValue * value = [NSValue valueWithBytes:&rawValue objCType:\@encode($propertyType)]; objc_setAssociatedObject(self, (void *)$propertyGetterName, value, OBJC_ASSOCIATION_RETAIN_NONATOMIC); }";
-	} else {
-		$setter_func .= "{ objc_setAssociatedObject(self, (void *)$propertyGetterName, rawValue, $propertyAssociationPolicy); }";
-	}
-
-	return "$getter_func; $setter_func";
+	return "";
 }
 
 sub initializers {
 	my $self = shift;
 	my $property = shift;
 
-	my $className = Logos::sigil("class", $property->group->name, $property->class->name);
+	my $className = $property->class->name;
+	my $logosClassVar = Logos::sigil("class", $property->group->name, $className);
+	my $readonly = $property->readonly;
+	my $retain = $property->retainFlag;
+	my $copy = $property->copyFlag;
+	my $nonatomic = $property->nonatomicFlag;
+	my $name = $property->name;
 	my $propertyType = $property->type;
 	my $propertyGetter = $property->getter;
 	my $propertyGetterName = $self->getterName($property);
 	my $propertySetter = $property->setter;
 	my $propertySetterName = $self->setterName($property);
 
-	my $build = "{ char _typeEncoding[1024];";
+	$propertyType =~ /([^ \*]+).+/;
+	my $propertyClassName = $1;
+	
+	my $build = "{ objc_property_attribute_t _attributes[16]; unsigned int attrc = 0;";
 
-	# Getter
-	$build .= " sprintf(_typeEncoding, \"%s\@:\", \@encode($propertyType));";
-	$build .= " class_addMethod($className, \@selector($propertyGetter), (IMP)&$propertyGetterName, _typeEncoding);";
+	# Property attributes
+	if ($retain) {
+		# Type encoding of objet properties should be `@"ClassName"`
+		$build .= $self->addAttribute("_attributes", "attrc", "T", "\"@\\\"$propertyClassName\\\"\"");
+		$build .= $self->addAttribute("_attributes", "attrc", "&"); #, "\"\"");
+	} else {
+		# Type encoding of non-object properties should be
+		$build .= $self->addAttribute("_attributes", "attrc", "T", "\@encode($propertyType)");
+	}
+	if ($readonly) {
+		$build .= $self->addAttribute("_attributes", "attrc", "R"); #, "\"\"");
+	}
 
-	# Setter
-	$build .= " sprintf(_typeEncoding, \"v\@:%s\", \@encode($propertyType));";
-	$build .= " class_addMethod($className, \@selector($propertySetter:), (IMP)&$propertySetterName, _typeEncoding);";
+	if ($copy) {
+		$build .= $self->addAttribute("_attributes", "attrc", "C"); #, "\"\"");
+	}
+	if ($nonatomic) {
+		$build .= $self->addAttribute("_attributes", "attrc", "N"); #, "\"\"");
+	}
+
+	# class_addProperty
+	$build .= " class_addProperty($logosClassVar, \"$name\", _attributes, attrc);";
+
+	# Only add methods if not readonly. Readonly properties do not
+	# have a getter synthesized for them since ivars cannot be added.
+	# The programmer is expected to implement the getter himself.
+	if (!$readonly) {
+		$build .= " char _typeEncoding[1024];";
+		# Getter
+		$build .= " sprintf(_typeEncoding, \"%s\@:\", \@encode($propertyType));";
+		$build .= " class_addMethod($logosClassVar, \@selector($propertyGetter), (IMP)&$propertyGetterName, _typeEncoding);";
+
+		# Setter
+		$build .= " sprintf(_typeEncoding, \"v\@:%s\", \@encode($propertyType));";
+		$build .= " class_addMethod($logosClassVar, \@selector($propertySetter:), (IMP)&$propertySetterName, _typeEncoding);";
+	}
 
 	$build .= " } ";
 

--- a/bin/lib/Logos/Generator/Base/Property.pm
+++ b/bin/lib/Logos/Generator/Base/Property.pm
@@ -5,13 +5,13 @@ use Logos::Util;
 sub getterName {
 	my $self = shift;
 	my $property = shift;
-	return Logos::sigil("method", $property->group->name, $property->class->name, $property->getter);
+	return Logos::sigil("property", $property->group->name, $property->class->name, $property->getter);
 }
 
 sub setterName {
 	my $self = shift;
 	my $property = shift;
-	return Logos::sigil("method", $property->group->name, $property->class->name, $property->setter);
+	return Logos::sigil("property", $property->group->name, $property->class->name, $property->setter);
 }
 
 sub definition {

--- a/bin/lib/Logos/Property.pm
+++ b/bin/lib/Logos/Property.pm
@@ -13,9 +13,13 @@ sub new {
 	$self->{GROUP} = undef;
 	$self->{NAME} = undef;
 	$self->{TYPE} = undef;
+	$self->{READONLY} = undef;
 	$self->{ASSOCIATIONPOLICY} = undef;
 	$self->{GETTER} = undef;
 	$self->{SETTER} = undef;
+	$self->{RETAIN_F} = undef;
+	$self->{COPY_F} = undef;
+	$self->{NONATOMIC_F} = undef;
 	bless($self, $class);
 	return $self;
 }
@@ -44,6 +48,12 @@ sub type {
 	return $self->{TYPE};
 }
 
+sub readonly {
+	my $self = shift;
+	if(@_) { $self->{READONLY} = shift; }
+	return $self->{READONLY};
+}
+
 sub associationPolicy {
 	my $self = shift;
 	if(@_) { $self->{ASSOCIATIONPOLICY} = shift; }
@@ -60,6 +70,24 @@ sub setter {
 	my $self = shift;
 	if(@_) { $self->{SETTER} = shift; }
 	return $self->{SETTER};
+}
+
+sub retainFlag {
+	my $self = shift;
+	if(@_) { $self->{RETAIN_F} = shift; }
+	return $self->{RETAIN_F};
+}
+
+sub copyFlag {
+	my $self = shift;
+	if(@_) { $self->{COPY_F} = shift; }
+	return $self->{COPY_F};
+}
+
+sub nonatomicFlag {
+	my $self = shift;
+	if(@_) { $self->{NONATOMIC_F} = shift; }
+	return $self->{NONATOMIC_F};
 }
 
 ##### #

--- a/bin/logos.pl
+++ b/bin/logos.pl
@@ -641,6 +641,12 @@ foreach my $line (@lines) {
 				fileError($lineno, "property attributes 'copy' and 'retain' are mutually exclusive.");
 			}
 
+			if($readonly) {
+				if($retain || $copy || $assign) {
+					fileError($lineno, "property attribute 'readonly' cannot be used with memory management attributes (assign, retain, copy).");
+				}
+			}
+
 			my $property = Property->new();
 			$property->class($currentClass);
 			$property->type($type);

--- a/bin/logos.pl
+++ b/bin/logos.pl
@@ -604,7 +604,7 @@ foreach my $line (@lines) {
 			my @attributes = split/\(?\s*,\s*\)?/, $1;
 			my $type = $2;
 			my $name = $3;
-			my ($assign, $retain, $copy, $nonatomic, $getter, $setter);
+			my ($assign, $retain, $copy, $nonatomic, $readonly, $getter, $setter);
 			my $numattr = 0;
 
 			foreach(@attributes) {
@@ -620,7 +620,9 @@ foreach my $line (@lines) {
 					$copy = 1;
 				} elsif($_ eq "nonatomic") {
 					$nonatomic = 1;
-				} elsif($_ =~ /readwrite|readonly|weak/) {
+				} elsif($_ eq "readonly") {
+					$readonly = 1;
+				} elsif($_ =~ /readwrite|weak|class/) {
 					fileError($lineno, "property attribute '".$_."' not supported.");
 				} else {
 					fileError($lineno, "unknown property attribute '".$_."'.");
@@ -643,6 +645,8 @@ foreach my $line (@lines) {
 			$property->class($currentClass);
 			$property->type($type);
 			$property->name($name);
+			$property->readonly($readonly);
+
 
 			if(!$assign && !$retain && !$copy) {
 				# No 'assign', 'retain', or 'copy' attribute is specified - 'assign' is assumed
@@ -668,6 +672,9 @@ foreach my $line (@lines) {
 			}
 
 			$property->associationPolicy($policy);
+			$property->retainFlag($retain);
+			$property->copyFlag($copy);
+			$property->nonatomicFlag($nonatomic);
 
 			if($currentGroup) {
 				$property->group($currentGroup);


### PR DESCRIPTION
## Motivation

`%properties` have a few problems currently:

- They don't generate `objc_property` metadata by calling into `class_addProperty`
- You cannot make a `readonly` property
- You cannot opt-out of backing storage
- You cannot override the synthesized methods and then call back into them with `%orig`

This PR resolves all of these issues.

### `readonly` Properties

Now, marking a %property as `readonly` will not synthesize a getter and setter.

#### Rationale

Clang will not synthesize a backing ivar when you implement both the getter and setter of a property (or when you implement the getter of a readonly property) because it reasonably assumes you don't _need_ backing storage

Likewise, if you mark a %property as `readonly` Logos will assume that you plan to add a computed property which doesn't need backing storage. This makes sense since Logos's generated getters use associated objects, and you would need to provide some kind of setter-logic if you did need backing storage.

### Overriding Properties

Prior to this, if you were to `%hook` a method and try to add a `%property` with the same name, the generated logos symbols would collide. This resolves that collision by renaming the symbol generated by Logos. `%property` method symbols now look like `…$myProperty$getter` or `…$myProperty$setter` instead of `…$myProperty` and `…$setMyProperty`

### Order of Class Initialization

Before, methods (hooks) were initialized before properties. This means that property methods didn't exist yet to be hooked. Swapping the order fixes this.

---

This closes #41