### PR TITLE
Fix double ", ..." in _methodPrototype of MobileSubstrate Generator

### DIFF
--- a/bin/lib/Logos/Generator/MobileSubstrate/Method.pm
+++ b/bin/lib/Logos/Generator/MobileSubstrate/Method.pm
@@ -31,9 +31,6 @@ sub _methodPrototype {
 	my $arglist = "";
 	if($includeArgNames == 1) {
 		map $arglist .= ", ".Logos::Method::declarationForTypeWithName($method->argtypes->[$_], $method->argnames->[$_]), (0..$method->numArgs - 1);
-		if($method->variadic) {
-			$arglist .= ", ...";
-		}
 	} else {
 		my $typelist = join(", ", @{$method->argtypes});
 		$arglist = ", ".$typelist if $typelist;


### PR DESCRIPTION
When trying to hook objc variadic method with default configuration(generator=MobileSubstrate), 
```
%hook NSString
+(id)stringWithFormat:(NSString *)format, ...
{
	va_list args;
        va_start(args, format); 
	id ret=[[NSString alloc] initWithFormat:format arguments:args];
	va_end(args);

	NSLog(@"%@",ret);
        return ret;
}
%end
```

compilation failed with log:
```
XXRootViewController.x:28:172: error: expected ')'
static id _logos_meta_method$_ungrouped$NSString$stringWithFormat$(_LOGOS_SELF_TYPE_NORMAL Class _LOGOS_SELF_CONST __unused self, SEL __unused _cmd, NSString * format, ..., ...) {
                                                                                                                                                                           ^
XXRootViewController.x:28:67: note: to match this '('
static id _logos_meta_method$_ungrouped$NSString$stringWithFormat$(_LOGOS_SELF_TYPE_NORMAL Class _LOGOS_SELF_CONST __unused self, SEL __unused _cmd, NSString * format, ..., ...) {
```
Obviously there are two `, ...` at the end of method arg list.

This PR fix this issue.

