### PR TITLE
Add basic libhooker API support

### DIFF
--- a/bin/lib/Logos/Generator/Base/Group.pm
+++ b/bin/lib/Logos/Generator/Base/Group.pm
@@ -14,7 +14,7 @@ sub declarations {
 sub initializers {
 	my $self = shift;
 	my $group = shift;
-	my $return = "{";
+	my $return = "{typedef void (*LOGOS_objchookfunc_ptr_t)(Class, SEL, IMP, IMP *);void *LOGOS_TMP_MESSAGE_PTR = dlsym(((void *) 0), \"LBHookMessage\"); LOGOS_objchookfunc_ptr_t LOGOS_HOOK_FUNC = LOGOS_TMP_MESSAGE_PTR != NULL ? (LOGOS_objchookfunc_ptr_t)LOGOS_TMP_MESSAGE_PTR : &MSHookMessageEx;";
 	foreach(@{$group->classes}) {
 		$return .= Logos::Generator::for($_)->initializers if $_->initRequired;
 	}

--- a/bin/lib/Logos/Generator/MobileSubstrate/Function.pm
+++ b/bin/lib/Logos/Generator/MobileSubstrate/Function.pm
@@ -6,12 +6,18 @@ sub initializers {
 	my $self = shift;
 	my $function = shift;
 
-	my $return = "";
-	$return .= "void * ".$self->variable($function)." = ".$self->_initExpression($function).";";
+	my $return = "{typedef void (*LOGOS_hookfuncs_ptr_t)(const struct LHFunctionHook *, int);LOGOS_hookfuncs_ptr_t LOGOS_C_HOOK_FUNC = (LOGOS_hookfuncs_ptr_t)dlsym(((void *)0), \"LHHookFunctions\");";
+	$return .= "if(LOGOS_C_HOOK_FUNC == NULL) {void * ".$self->variable($function)." = ".$self->_initExpression($function).";";
 	$return .= " MSHookFunction((void *)".$self->variable($function);
 	$return .= ", (void *)&".$self->newFunctionName($function);
 	$return .= ", (void **)&".$self->originalFunctionName($function);
-	$return .= ");";
+	$return .= ");}else{";
+	$return .= "void * ".$self->variable($function)." = ".$self->_initExpression($function).";";
+	## TODO: Add the LHFunctionHook struct to an array and then call LHHookFunctions only once
+	$return .= "LHFunctionHook hook;hook.function = (void *)".$self->variable($function);
+	$return .= ";hook.replacement = (void *)&".$self->newFunctionName($function);
+	$return .= ";hook.oldptr = (void **)&".$self->originalFunctionName($function);
+	$return .= ";const struct LHFunctionHook *hooks = {&hook};LOGOS_C_HOOK_FUNC(hooks, 1);}}";
 
 	return $return;
 }

--- a/bin/lib/Logos/Generator/MobileSubstrate/Generator.pm
+++ b/bin/lib/Logos/Generator/MobileSubstrate/Generator.pm
@@ -15,7 +15,7 @@ sub preamble {
 	if ($skipIncludes) {
 		return $self->SUPER::preamble();
 	} else {
-		return join("\n", ($self->SUPER::preamble(), "#include <substrate.h>"));
+		return join("\n", ($self->SUPER::preamble(), "#include <substrate.h>\n#include <libhooker.h>\n#include <dlfcn.h>"));
 	}
 }
 

--- a/bin/lib/Logos/Generator/MobileSubstrate/Method.pm
+++ b/bin/lib/Logos/Generator/MobileSubstrate/Method.pm
@@ -90,7 +90,7 @@ sub initializers {
 	my $classvar = ($method->scope eq "+" ? $cgen->metaVariable : $cgen->variable);
 	my $r = "{ ";
 	if(!$method->isNew) {
-		$r .= "MSHookMessageEx(".$classvar.", ".$self->selectorRef($method->selector).", (IMP)&".$self->newFunctionName($method).", (IMP*)&".$self->originalFunctionName($method).");";
+		$r .= "LOGOS_HOOK_FUNC(".$classvar.", ".$self->selectorRef($method->selector).", (IMP)&".$self->newFunctionName($method).", (IMP*)&".$self->originalFunctionName($method).");";
 	} else {
 		if(!$method->type) {
 			$r .= "char _typeEncoding[1024]; unsigned int i = 0; ";


### PR DESCRIPTION
**DISCLAIMER: This is not in any way finished, I don't even know perl. It is my hopes this can be a good starting point that other, smarter people can use to build from**
This pull request adds support for using the libhooker APIs directly if available, and falling back to MobileSubstrate

Does this provide any real benefit for end users? No, not really, the shims for MobileSubstrate functions on libhooker still work fine; the only case the shim could really be less efficient than directly supporting the libhooker API is when hooking C functions.

Quite simply, I made this pull request because Coolstar said "why don't you make a PR for logos then if it's that easy". It was that easy. 

What needs to be done before merging:
- Actually batch hooking for C functions as to not dlsym and call LHHookFunctions for every one (this probably would require a lot of work, but this would allow Logos hookf to utilize the benefits of libhooker's API)
- Perhaps clean up the code