### PR TITLE
Check %property for attributes before assigning to array

### DIFF
--- a/bin/logos.pl
+++ b/bin/logos.pl
@@ -600,6 +600,11 @@ foreach my $line (@lines) {
 
 			$currentClass->hasinstancehooks(1);
 
+			# check %property for attributes
+			if (!defined $1 || $1 eq '') {
+				fileError($lineno, "%property declaration is missing attributes (e.g., nonatomic, retain, etc)");
+			}
+
 			# check property attribute validity
 			my @attributes = split/\(?\s*,\s*\)?/, $1;
 			my $type = $2;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Adds a check for $1 before its use 

Does this close any currently open issues?
------------------------------------------
Should resolve #69 

Any relevant logs, error output, etc?
-------------------------------------
Using the code provided in the issue, logos spits out 
```Use of uninitialized value $1 in split at /home/lightmann/theos/bin/logos.pl line 604.```
and does not fail the build.

With this change, logos now spits out
```Tweak.x:8: error: %property declaration is missing attributes (e.g., nonatomic, retain, etc)```
and *does* fail the build.

Any other comments?
-------------------
Clang will spit out an error if the %property is missing a type or name (though the error isn't particularly useful), so it doesn't seem like a check is necessary for them. 

Where has this been tested?
---------------------------
**Operating System:** …

Linux (WSL)

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
