### PR TITLE
[Fix 80] space/newline in %init causes issues

### DIFF
--- a/bin/logos.pl
+++ b/bin/logos.pl
@@ -544,6 +544,7 @@ foreach my $line (@lines) {
 				my $expr = $parts[1];
 
 				my $classname = $parts[0];
+				$classname =~ s/^\s+//;
 				my $scope = "-";
 				if($classname =~ /^([+-])/) {
 					$scope = $1;


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
space/newline in %init causes the first class to be prefixed with invalid spaces

Does this close any currently open issues?
------------------------------------------
#80