### PR TITLE
Switch from sprintf to snprintf. sprintf is deprecated.

### DIFF
--- a/bin/lib/Logos/Generator/Base/Property.pm
+++ b/bin/lib/Logos/Generator/Base/Property.pm
@@ -121,7 +121,7 @@ sub initializers {
 		$build .= " size_t _nBytes = 1024;";
 		$build .= " char _typeEncoding[_nBytes];";
 		# Getter
-		$build .= " snprintf(_typeEncoding, _nBytes,\"%s\@:\", \@encode($propertyType));";
+		$build .= " snprintf(_typeEncoding, _nBytes, \"%s\@:\", \@encode($propertyType));";
 		$build .= " class_addMethod($logosClassVar, \@selector($propertyGetter), (IMP)&$propertyGetterName, _typeEncoding);";
 
 		# Setter

--- a/bin/lib/Logos/Generator/Base/Property.pm
+++ b/bin/lib/Logos/Generator/Base/Property.pm
@@ -118,13 +118,14 @@ sub initializers {
 	# have a getter synthesized for them since ivars cannot be added.
 	# The programmer is expected to implement the getter himself.
 	if (!$readonly) {
-		$build .= " char _typeEncoding[1024];";
+		$build .= " size_t _nBytes = 1024;";
+		$build .= " char _typeEncoding[_nBytes];";
 		# Getter
-		$build .= " sprintf(_typeEncoding, \"%s\@:\", \@encode($propertyType));";
+		$build .= " snprintf(_typeEncoding, _nBytes,\"%s\@:\", \@encode($propertyType));";
 		$build .= " class_addMethod($logosClassVar, \@selector($propertyGetter), (IMP)&$propertyGetterName, _typeEncoding);";
 
 		# Setter
-		$build .= " sprintf(_typeEncoding, \"v\@:%s\", \@encode($propertyType));";
+		$build .= " snprintf(_typeEncoding, _nBytes, \"v\@:%s\", \@encode($propertyType));";
 		$build .= " class_addMethod($logosClassVar, \@selector($propertySetter:), (IMP)&$propertySetterName, _typeEncoding);";
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
sprintf is deprecated, use of snprintf instead to avoid warnings.

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** …

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
