### PR TITLE
Add check for %group's within %hook's

### DIFF
--- a/bin/logos.pl
+++ b/bin/logos.pl
@@ -280,8 +280,8 @@ foreach my $line (@lines) {
 			fileError($lineno, "%group does not make sense inside a block") if($directiveDepth >= 1);
 
 			# find any hooks in the current nestingstack
-			my(@indexes) = grep { $nestingstack[$_] =~ /\%hook/ } 0..$#nestingstack;
-			foreach my $i (0..$#nestingstack) {
+			my(@indexes) = grep { $nestingstack[$_] =~ /hook/ } 0..$#nestingstack;
+			foreach my $i (@indexes) {
 				# grab line number for each hook and check
 				# against the current lineno of the %group(s)
 				(my $hookno = $nestingstack[$i]) =~ s/\D//g;

--- a/bin/logos.pl
+++ b/bin/logos.pl
@@ -278,6 +278,16 @@ foreach my $line (@lines) {
 		} elsif($line =~ /\G%group\s+([\$_\w]+)/gc) {
 			# %group <identifier>
 			fileError($lineno, "%group does not make sense inside a block") if($directiveDepth >= 1);
+
+			# find any hooks in the current nestingstack
+			my(@indexes) = grep { $nestingstack[$_] =~ /\%hook/ } 0..$#nestingstack;
+			foreach my $i (0..$#nestingstack) {
+				# grab line number for each hook and check
+				# against the current lineno of the %group(s)
+				(my $hookno = $nestingstack[$i]) =~ s/\D//g;
+				fileError($lineno, "%group does not make sense inside a hook") if($hookno < $lineno);
+			}
+
 			nestingMustNotContain($lineno, "%group", \@nestingstack, "group");
 
 			@firstDirectivePosition = ($lineno, $-[0]) if !@firstDirectivePosition;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
See title

Does this close any currently open issues?
------------------------------------------
I believe this will resolve #45

Any relevant logs, error output, etc?
-------------------------------------
For the following code (as well as the code provided in the issue mentioned above):
```logos
%hook ClassToBeHooked
%group someThing
-(void)thing{
}
%end
%end

%ctor {
    %init(someThing);
}
```
Previously: successful preprocess 
Now: `Tweak.xm:<line>: error: %group does not make sense inside a hook`

Any other comments?
-------------------
For
```logos
%group someThing2
%hook ClassToBeHooked2
-(void)thing2{
}
%end
%end

%group someThing
%hook ClassToBeHooked
-(void)thing{
}
%end
%end

%ctor {
    %init(someThing2);
    %init(someThing);
}
```
the `nestingstack` is shown to be:
```
nestingstack: group:59
nestingstack: group:59 hook:60
nestingstack: group:59 hook:60
nestingstack: group:59
nestingstack:
nestingstack: group:66
nestingstack: group:66 hook:67
nestingstack: group:66 hook:67
nestingstack: group:66
```
Based on this, it seems like the `nestingstack` array is cleaned up as items are %end'ed. Assuming this is correct, earlier hooks shouldn't interfere with the logic used to determine an open hook's location relative to the group in question. These assumptions may be incorrect, however, in which case this can be put on ice until a more thorough impl is thought up. It appears to work as intended in my testing though. 

Where has this been tested?
---------------------------
**Operating System:** …

Linux (WSL)

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
