### PR TITLE
Add fallback condition when adding a protocol to a subclass

### DIFF
--- a/bin/lib/Logos/Generator/MobileSubstrate/Subclass.pm
+++ b/bin/lib/Logos/Generator/MobileSubstrate/Subclass.pm
@@ -23,7 +23,7 @@ sub initializers {
 	}
 	# </ivars>
 	foreach(keys %{$class->protocols}) {
-		$return .= "class_addProtocol(".$self->variable($class).", objc_getProtocol(\"$_\")); ";
+		$return .= "class_addProtocol(".$self->variable($class).", objc_getProtocol(\"$_\") ? objc_getProtocol(\"$_\") : \@protocol($_)); ";
 	}
 	$return .= "}";
 	return $return;

--- a/bin/lib/Logos/Generator/internal/Subclass.pm
+++ b/bin/lib/Logos/Generator/internal/Subclass.pm
@@ -24,7 +24,7 @@ sub initializers {
 	# </ivars>
 	$return .= "objc_registerClassPair(".$self->variable($class)."); ";
 	foreach(keys %{$class->protocols}) {
-		$return .= "class_addProtocol(".$self->variable($class).", objc_getProtocol(\"$_\")); ";
+		$return .= "class_addProtocol(".$self->variable($class).", objc_getProtocol(\"$_\") ? objc_getProtocol(\"$_\") : \@protocol($_)); ";
 	}
 	$return .= "}";
 	return $return;

--- a/bin/lib/Logos/Generator/libhooker/Subclass.pm
+++ b/bin/lib/Logos/Generator/libhooker/Subclass.pm
@@ -23,7 +23,7 @@ sub initializers {
 	}
 	# </ivars>
 	foreach(keys %{$class->protocols}) {
-		$return .= "class_addProtocol(".$self->variable($class).", objc_getProtocol(\"$_\")); ";
+		$return .= "class_addProtocol(".$self->variable($class).", objc_getProtocol(\"$_\") ? objc_getProtocol(\"$_\") : \@protocol($_)); ";
 	}
 	$return .= "}";
 	return $return;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Implements a fallback to `objc_getProtocol` in `%subclass` as proposed by RPetrich in https://github.com/theos/logos/issues/9#issuecomment-183460233

Does this close any currently open issues?
------------------------------------------
Appears to resolve #9 

Any relevant logs, error output, etc?
-------------------------------------
N/A

Any other comments?
-------------------
With the following code (a modified version of the code mentioned in the issue above):
```logos
@protocol CCSectionDelegate <NSObject>
- (void)updateStatusText:(NSString *)text;
- (void)requestControlCenterDismissal;
- (void)sectionHeightChanged;
- (void)showViewController:(UIViewController *)vc animated:(BOOL)animated completion:(void (^)(void))completion;
@end

%subclass CCSectionViewController : SpringBoard <CCSectionDelegate, UICollectionViewDelegate>
%end
```
Current logos: crash
This branch: no crash

Where has this been tested?
---------------------------
**Operating System:** …

Linux (WSL)
iP7 -- iOS 14.3 - unc0ver

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
