### PR TITLE
Define blocks as objects

### DIFF
--- a/bin/lib/Logos/Method.pm
+++ b/bin/lib/Logos/Method.pm
@@ -197,6 +197,7 @@ sub formatCharForArgType {
 	# Objects
 	return "%@" if /^instancetype$/; # instancetype is an objc_object.
 	return "%@" if /^id$/; # id is an objc_object.
+	return "%@" if /^*\(\^\).*$/; # blocks are objc_objects (matches non-typedef blocks).
 	return "%@" if /^\w+\s*\*$/; # try to treat *any* other pointer as an objc_object.
 	return "%@" if /^\w+Ref$/; # *Ref can be printed with %@.
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Adds a check for ```(^)``` and returns the type as `%@` as proposed by Kirb in https://github.com/theos/logos/issues/12#issuecomment-284217410

Does this close any currently open issues?
------------------------------------------
- I believe it would close #12, though 1) the error log linked in the issue no longer exists and 2) I was unable to repro an error
- This pr simply provides more information in %log's text for block parameters (see below).

Any relevant logs, error output, etc?
-------------------------------------
For:
```logos
%hook IALBackupManager
-(void)makeBackupWithFilter:(BOOL)filter andCompletion:(void (^)(BOOL))block {
	%log;
	%orig;
}
%end
```

Before:
```objc
NSLog(@"-[<IALBackupManager: %p> makeBackupWithFilter:%d andCompletion:0x%llx]", self, filter, (uint64_t)block);
```
```shell
IAmLazy[5455] <Notice>: -[<IALBackupManager: 0x280125fe0> makeBackupWithFilter:1 andCompletion:0x16bc9e3f8]
```

After:
```objc
NSLog(@"-[<IALBackupManager: %p> makeBackupWithFilter:%d andCompletion:%@]", self, filter, block)
```
```shell
IAmLazy[5144] <Notice>: -[<IALBackupManager: 0x282c95ce0> makeBackupWithFilter:1 andCompletion:<__NSMallocBlock__: 0x282c95d10>]
```

Any other comments?
-------------------
- Regex based off of Kirb's comment and https://fuckingblocksyntax.com/

Where has this been tested?
---------------------------
**Operating System:** …

Linux (WSL)
iP7 -- iOS 14.3 -- unc0ver

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
