### PR TITLE
Properly handle single-line mixed-format comments

### DIFF
--- a/bin/logos.pl
+++ b/bin/logos.pl
@@ -91,7 +91,8 @@ READLOOP: while(my $line = <FILE>) {
 	# Delete all single-line to-EOL // xxx comments.
 	# This needs to be first so that //*something doesn't match as a /*
 	while($line =~ /\/\//g) {
-		next if fallsBetween($-[0], @quotes);
+		# If // is part of a single-line /**/ comment, skip and handle below
+		next if ($line =~ /^.*?\*\/\s*/ || fallsBetween($-[0], @quotes));
 		$line = $`;
 		redo READLOOP;
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
See title

Does this close any currently open issues?
------------------------------------------
Appears to resolve #66, #70, and #77

Any relevant logs, error output, etc?
-------------------------------------
N/A

Any other comments?
-------------------
Tested with:
- Modified code from #66
```logos
%ctor{
    /* https://www.google.com */

    /*
    https://www.google.com
    */

    /*
    test
    */

    // test

    //*test
}
```

- Modified code from #70
```logos
%ctor {
  // ...
}

/* Multiline comment including a // line comment */

// These lines are incorrectly ignored:

int func() {
    int a = 3;
    return a;
    /* Another multiline comment; its closing sequence will be noticed */
    // The line below will cause an error
}
```

- Modified code from #77
```logos
%ctor{
    /*// }}}*/
    /*// }}}*/
}
```

Output (all three examples in the same file with whitespace removed for brevity):
```objc
static __attribute__((constructor)) void _logosLocalCtor_5784034e(int __unused argc, char __unused **argv, char __unused **envp){    
}

static __attribute__((constructor)) void _logosLocalCtor_f0225b01(int __unused argc, char __unused **argv, char __unused **envp) { 
}

int func() {
    int a = 3;
    return a;
}

static __attribute__((constructor)) void _logosLocalCtor_854fe05f(int __unused argc, char __unused **argv, char __unused **envp){
}
```

Where has this been tested?
---------------------------
**Operating System:** …

Linux (WSL)

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
