### PR TITLE
Treat ' as a valid quote

### DIFF
--- a/bin/lib/Logos/Util.pm
+++ b/bin/lib/Logos/Util.pm
@@ -12,7 +12,7 @@ sub _defaultErrorHandler {
 sub quotes {
 	my ($line) = @_;
 	my @quotes = ();
-	while($line =~ /(?<!\\)\"/g) {
+	while($line =~ /(?<!\\)[\"\']/g) {
 		push(@quotes, $-[0]);
 	}
 	return @quotes;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
See title

Does this close any currently open issues?
------------------------------------------
Appears to fix #97 

Any relevant logs, error output, etc?
-------------------------------------
N/A

Any other comments?
-------------------
With the code provided in the issue:
```logos
%ctor {
        char test = '}'
        if (test == 'a') {
                printf("the thing!\n");
        }
}
```
previously (printing each `$line` in `sub quotes`):
```
line:           printf("the thing!\n");
line:           printf("the thing!\n");
line:           printf("the thing!\n");
line:           printf("the thing!\n");
/home/lightmann/97-test.x:6: error: fell off the face of the planet when we found a '}'
```
now:
```
line:   char test = '}'
line:   char test = '}'
line:   if (test == 'a') {
line:   if (test == 'a') {
line:           printf("the thing!\n");
line:           printf("the thing!\n");
line:   char test = '}'
line:   char test = '}'
line:   if (test == 'a') {
line:   if (test == 'a') {
line:           printf("the thing!\n");
line:           printf("the thing!\n");
#line 1 "/home/lightmann/97-test.x"
static __attribute__((constructor)) void _logosLocalCtor_bc7a1431(int __unused argc, char __unused **argv, char __unused **envp) {
        char test = '}'
        if (test == 'a') {
                printf("the thing!\n");
        }
}
```

Unsure about repercussions elsewhere if `sub quotes` is modified, but it should be fine?

Where has this been tested?
---------------------------
**Operating System:** …

Linux (WSL)

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
