### PR TITLE
Make libhooker generator support compilation w/o clang modules

### DIFF
--- a/bin/lib/Logos/Generator/libhooker/Generator.pm
+++ b/bin/lib/Logos/Generator/libhooker/Generator.pm
@@ -15,7 +15,7 @@ sub preamble {
 	if ($skipIncludes) {
 		return $self->SUPER::preamble();
 	} else {
-		return join("\n", ($self->SUPER::preamble(), "\@import libhooker.libblackjack;\n\@import ObjectiveC.runtime;"));
+		return join("\n", ($self->SUPER::preamble(), "#import <libhooker/libblackjack.h>\n#import <objc/runtime.h>"));
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
See title

Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
If modules are enabled, these #imports will become module imports 

Where has this been tested?
---------------------------
**Operating System:** …

Linux (WSL)

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
