### PR TITLE
Simplify base generator's `staticDeclarations`

### DIFF
--- a/bin/lib/Logos/Generator/Base/Generator.pm
+++ b/bin/lib/Logos/Generator/Base/Generator.pm
@@ -15,18 +15,11 @@ sub preamble {
 sub staticDeclarations {
 	my $self = shift;
 	return <<END;
-#if defined(__clang__)
-#if __has_feature(objc_arc)
+#if defined(__clang__) && __has_feature(objc_arc)
 #define _LOGOS_SELF_TYPE_NORMAL __unsafe_unretained
 #define _LOGOS_SELF_TYPE_INIT __attribute__((ns_consumed))
 #define _LOGOS_SELF_CONST const
 #define _LOGOS_RETURN_RETAINED __attribute__((ns_returns_retained))
-#else
-#define _LOGOS_SELF_TYPE_NORMAL
-#define _LOGOS_SELF_TYPE_INIT
-#define _LOGOS_SELF_CONST
-#define _LOGOS_RETURN_RETAINED
-#endif
 #else
 #define _LOGOS_SELF_TYPE_NORMAL
 #define _LOGOS_SELF_TYPE_INIT


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Simplifies the macro conditional used to set various Logos constants 

Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
N/A

Where has this been tested?
---------------------------
**Operating System:** …

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
