### PR TITLE
[libhooker] Bracket array parameter to LHHookFunctions

### DIFF
--- a/bin/lib/Logos/Generator/libhooker/Group.pm
+++ b/bin/lib/Logos/Generator/libhooker/Group.pm
@@ -11,7 +11,7 @@ sub initializers {
 	}
 	my @structs = map { Logos::Generator::for($_)->initializers } @{$group->functions};
 	my $functionCount = @{$group->functions};
-	$return .= "LHHookFunctions(".join(",", @structs).", ".$functionCount.");";
+	$return .= "LHHookFunctions((struct LHFunctionHook []){".join(",", @structs)."}, ".$functionCount.");";
 	$return .= "}";
 	return $return;
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

The current version of the `libhooker` generator fails to generate code that compiles under clang 15.

In either case where there are 0 or more `%hookf` occurrences (i.e. function hooks), the code emitted is not valid.

For example, when there are 0 occurrences of `%hookf` (#103 also mentions this case), the generated code looks like:

```c
LHHookFunctions(, 0);
```

(error because the first parameter is completely missing.)

When this is 1 occurrence of `%hookf` (using sample from docs), then generated code looks like:

```c
LHHookFunctions({(void *)fopen, (void *)&_logos_function$_ungrouped$fopen, (void **)&_logos_orig$_ungrouped$fopen}, 1);
```

(error because the first parameter is supposed to be an array of structs, but it's an array of `void *`.)

Does this close any currently open issues?
------------------------------------------
no


Any relevant logs, error output, etc?
-------------------------------------

Generated code for the two examples above using this PR:

0 function hooks case:

```c
LHHookFunctions((struct LHFunctionHook []){}, 0);
```

1 function hook case:

```c
LHHookFunctions((struct LHFunctionHook []){{(void *)fopen, (void *)&_logos_function$_ungrouped$fopen, (void **)&_logos_orig$_ungrouped$fopen}}, 1);
```

Any other comments?
-------------------
Both snippets above compile.

Sample project:

  `Makefile`
  
  ```make
  TARGET := iphone:clang:16.5:14.0
  
  include $(THEOS)/makefiles/common.mk
  
  TWEAK_NAME = Sample
  
  Sample_FILES = Tweak.x
  Sample_CFLAGS = -fobjc-arc
  Sample_LOGOS_DEFAULT_GENERATOR = libhooker
  
  include $(THEOS_MAKE_PATH)/tweak.mk
  ```

  `Tweak.x`
  
  ```logos
  #import <Foundation/Foundation.h>
  
  %hook NSObject
  
  - (void)sample {
  }
  
  %end
  
  %hookf(FILE *, fopen, const char *path, const char *mode) {
      return %orig;
  }
  ```

Where has this been tested?
---------------------------
**Operating System:** macOS

**Platform:** Darwin

**Target Platform:** iPhoneOS

**Toolchain Version:** `clang version 15.0.0`

**SDK Version:** 16.5
