### PR TITLE
[Generator] Add required linker_option for each generator

### DIFF
--- a/bin/lib/Logos/Generator/MobileSubstrate/Generator.pm
+++ b/bin/lib/Logos/Generator/MobileSubstrate/Generator.pm
@@ -20,10 +20,11 @@ sub preamble {
 }
 
 sub staticDeclarations {
-    my $self = shift;
-    return join("\n", ($self->SUPER::staticDeclarations(),
-        "asm(\".linker_option \\\"-framework\\\", \\\"CydiaSubstrate\\\"\");",
-    ));
+	my $self = shift;
+	return join("\n", ($self->SUPER::staticDeclarations(),
+		"asm(\".linker_option \\\"-framework\\\", \\\"CydiaSubstrate\\\"\");",
+		"" # extra line break for readability
+	));
 }
 
 1;

--- a/bin/lib/Logos/Generator/MobileSubstrate/Generator.pm
+++ b/bin/lib/Logos/Generator/MobileSubstrate/Generator.pm
@@ -19,4 +19,11 @@ sub preamble {
 	}
 }
 
+sub staticDeclarations {
+    my $self = shift;
+    return join("\n", ($self->SUPER::staticDeclarations(),
+        "asm(\".linker_option \\\"-framework\\\", \\\"CydiaSubstrate\\\"\");",
+    ));
+}
+
 1;

--- a/bin/lib/Logos/Generator/libhooker/Generator.pm
+++ b/bin/lib/Logos/Generator/libhooker/Generator.pm
@@ -15,16 +15,20 @@ sub preamble {
 	if ($skipIncludes) {
 		return $self->SUPER::preamble();
 	} else {
-		return join("\n", ($self->SUPER::preamble(), "#import <libhooker/libblackjack.h>\n#import <objc/runtime.h>"));
+		return join("\n", ($self->SUPER::preamble(),
+			"#import <libhooker/libblackjack.h>",
+			"#import <objc/runtime.h>"
+		));
 	}
 }
 
 sub staticDeclarations {
-    my $self = shift;
-    return join("\n", ($self->SUPER::staticDeclarations(),
-        "asm(\".linker_option \\\"-lhooker\\\"\");",
-        "asm(\".linker_option \\\"-lblackjack\\\"\");"
-    ));
+	my $self = shift;
+	return join("\n", ($self->SUPER::staticDeclarations(),
+		"asm(\".linker_option \\\"-lhooker\\\"\");",
+		"asm(\".linker_option \\\"-lblackjack\\\"\");",
+		"" # extra line break for readability
+	));
 }
 
 1;

--- a/bin/lib/Logos/Generator/libhooker/Generator.pm
+++ b/bin/lib/Logos/Generator/libhooker/Generator.pm
@@ -19,4 +19,12 @@ sub preamble {
 	}
 }
 
+sub staticDeclarations {
+    my $self = shift;
+    return join("\n", ($self->SUPER::staticDeclarations(),
+        "asm(\".linker_option \\\"-lhooker\\\"\");",
+        "asm(\".linker_option \\\"-lblackjack\\\"\");"
+    ));
+}
+
 1;


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This PR aims to fix the problem that logos consumers need to have knowledge about the generator used in order to link the supporting library/ framework. More information about this problem in captured in theos/theos#729

To address the problem described above, this PR uses the `.linker_option` directive to include the library/ framework linking requirement within the resulting source code. 

Helpful article: https://www.smileykeith.com/2022/02/23/lc-linker-option/

The `.linker_option` directive was introduced in this LLVM commit: https://github.com/llvm/llvm-project/commit/16004b832422e5493de1d54f225eaed215b0526c which we can see is included in LLVM 3.3 and newer.

In additional testing, I found that including `-framework CydiaSubstrate`, for example, in both `.linker_option` and `LDFLAGS` does not appear to be an issue. Specifically, only 1 load command (checked with `otool -L`) is generated for `CydiaSubstrate` in this case.

Does this close any currently open issues?
------------------------------------------
No, but it's the first step to fixing theos/theos#729

Any relevant logs, error output, etc?
-------------------------------------

`Tweak.x`

```logos
#import <Foundation/Foundation.h>

%hook NSObject

- (void)sample {
}

%end

%hookf(FILE *, fopen, const char *path, const char *mode) {
	return %orig;
}
```

`$THEOS/bin/logos.pl -c generator=MobileSubstrate Tweak.x`:

```objc
#line 1 "Tweak.x"
#import <Foundation/Foundation.h>


#include <substrate.h>
#if defined(__clang__)
#if __has_feature(objc_arc)
#define _LOGOS_SELF_TYPE_NORMAL __unsafe_unretained
#define _LOGOS_SELF_TYPE_INIT __attribute__((ns_consumed))
#define _LOGOS_SELF_CONST const
#define _LOGOS_RETURN_RETAINED __attribute__((ns_returns_retained))
#else
#define _LOGOS_SELF_TYPE_NORMAL
#define _LOGOS_SELF_TYPE_INIT
#define _LOGOS_SELF_CONST
#define _LOGOS_RETURN_RETAINED
#endif
#else
#define _LOGOS_SELF_TYPE_NORMAL
#define _LOGOS_SELF_TYPE_INIT
#define _LOGOS_SELF_CONST
#define _LOGOS_RETURN_RETAINED
#endif

asm(".linker_option \"-framework\", \"CydiaSubstrate\"");

@class NSObject; 
static void (*_logos_orig$_ungrouped$NSObject$sample)(_LOGOS_SELF_TYPE_NORMAL NSObject* _LOGOS_SELF_CONST, SEL); static void _logos_method$_ungrouped$NSObject$sample(_LOGOS_SELF_TYPE_NORMAL NSObject* _LOGOS_SELF_CONST, SEL); 

#line 3 "Tweak.x"


static void _logos_method$_ungrouped$NSObject$sample(_LOGOS_SELF_TYPE_NORMAL NSObject* _LOGOS_SELF_CONST __unused self, SEL __unused _cmd) {
}



__unused static FILE * (*_logos_orig$_ungrouped$fopen)(const char *path, const char *mode); __unused static FILE * _logos_function$_ungrouped$fopen(const char *path, const char *mode) {
	return _logos_orig$_ungrouped$fopen(path, mode);
}
static __attribute__((constructor)) void _logosLocalInit() {
{Class _logos_class$_ungrouped$NSObject = objc_getClass("NSObject"); { MSHookMessageEx(_logos_class$_ungrouped$NSObject, @selector(sample), (IMP)&_logos_method$_ungrouped$NSObject$sample, (IMP*)&_logos_orig$_ungrouped$NSObject$sample);}void * _logos_symbol$_ungrouped$fopen = (void *)fopen; MSHookFunction((void *)_logos_symbol$_ungrouped$fopen, (void *)&_logos_function$_ungrouped$fopen, (void **)&_logos_orig$_ungrouped$fopen);} }
#line 13 "Tweak.x"
```

`$THEOS/bin/logos.pl -c generator=libhooker Tweak.x`:

```objc
#line 1 "Tweak.x"
#import <Foundation/Foundation.h>


#import <libhooker/libblackjack.h>
#import <objc/runtime.h>
#if defined(__clang__)
#if __has_feature(objc_arc)
#define _LOGOS_SELF_TYPE_NORMAL __unsafe_unretained
#define _LOGOS_SELF_TYPE_INIT __attribute__((ns_consumed))
#define _LOGOS_SELF_CONST const
#define _LOGOS_RETURN_RETAINED __attribute__((ns_returns_retained))
#else
#define _LOGOS_SELF_TYPE_NORMAL
#define _LOGOS_SELF_TYPE_INIT
#define _LOGOS_SELF_CONST
#define _LOGOS_RETURN_RETAINED
#endif
#else
#define _LOGOS_SELF_TYPE_NORMAL
#define _LOGOS_SELF_TYPE_INIT
#define _LOGOS_SELF_CONST
#define _LOGOS_RETURN_RETAINED
#endif

asm(".linker_option \"-lhooker\"");
asm(".linker_option \"-lblackjack\"");

@class NSObject; 
static void (*_logos_orig$_ungrouped$NSObject$sample)(_LOGOS_SELF_TYPE_NORMAL NSObject* _LOGOS_SELF_CONST, SEL); static void _logos_method$_ungrouped$NSObject$sample(_LOGOS_SELF_TYPE_NORMAL NSObject* _LOGOS_SELF_CONST, SEL); 

#line 3 "Tweak.x"


static void _logos_method$_ungrouped$NSObject$sample(_LOGOS_SELF_TYPE_NORMAL NSObject* _LOGOS_SELF_CONST __unused self, SEL __unused _cmd) {
}



__unused static FILE * (*_logos_orig$_ungrouped$fopen)(const char *path, const char *mode); __unused static FILE * _logos_function$_ungrouped$fopen(const char *path, const char *mode) {
	return _logos_orig$_ungrouped$fopen(path, mode);
}
static __attribute__((constructor)) void _logosLocalInit() {
{Class _logos_class$_ungrouped$NSObject = objc_getClass("NSObject"); LBHookMessage(_logos_class$_ungrouped$NSObject, @selector(sample), (void *)&_logos_method$_ungrouped$NSObject$sample, (void *)&_logos_orig$_ungrouped$NSObject$sample);LHHookFunctions((struct LHFunctionHook []){{(void *)fopen, (void *)&_logos_function$_ungrouped$fopen, (void **)&_logos_orig$_ungrouped$fopen}}, 1);} }
#line 13 "Tweak.x"
```

`$THEOS/bin/logos.pl -c generator=internal Tweak.x`:

```objc
#line 1 "Tweak.x"
#import <Foundation/Foundation.h>


#include <objc/message.h>
#if defined(__clang__)
#if __has_feature(objc_arc)
#define _LOGOS_SELF_TYPE_NORMAL __unsafe_unretained
#define _LOGOS_SELF_TYPE_INIT __attribute__((ns_consumed))
#define _LOGOS_SELF_CONST const
#define _LOGOS_RETURN_RETAINED __attribute__((ns_returns_retained))
#else
#define _LOGOS_SELF_TYPE_NORMAL
#define _LOGOS_SELF_TYPE_INIT
#define _LOGOS_SELF_CONST
#define _LOGOS_RETURN_RETAINED
#endif
#else
#define _LOGOS_SELF_TYPE_NORMAL
#define _LOGOS_SELF_TYPE_INIT
#define _LOGOS_SELF_CONST
#define _LOGOS_RETURN_RETAINED
#endif

__attribute__((unused)) static void _logos_register_hook(Class _class, SEL _cmd, IMP _new, IMP *_old) {
unsigned int _count, _i;
Class _searchedClass = _class;
Method *_methods;
while (_searchedClass) {
_methods = class_copyMethodList(_searchedClass, &_count);
for (_i = 0; _i < _count; _i++) {
if (method_getName(_methods[_i]) == _cmd) {
if (_class == _searchedClass) {
*_old = method_setImplementation(_methods[_i], _new);
} else {
*_old = method_getImplementation(_methods[_i]);
class_addMethod(_class, _cmd, _new, method_getTypeEncoding(_methods[_i]));
}
free(_methods);
return;
}
}
free(_methods);
_searchedClass = class_getSuperclass(_searchedClass);
}
}
@class NSObject; 
static Class _logos_superclass$_ungrouped$NSObject; static void (*_logos_orig$_ungrouped$NSObject$sample)(_LOGOS_SELF_TYPE_NORMAL NSObject* _LOGOS_SELF_CONST, SEL);

#line 3 "Tweak.x"


static void _logos_method$_ungrouped$NSObject$sample(_LOGOS_SELF_TYPE_NORMAL NSObject* _LOGOS_SELF_CONST __unused self, SEL __unused _cmd) {
}



__unused static FILE * (*_logos_orig$_ungrouped$fopen)(const char *path, const char *mode); __unused static FILE * _logos_function$_ungrouped$fopen(const char *path, const char *mode) {
	return _logos_orig$_ungrouped$fopen(path, mode);
}
static __attribute__((constructor)) void _logosLocalInit() {
{Class _logos_class$_ungrouped$NSObject = objc_getClass("NSObject"); _logos_superclass$_ungrouped$NSObject = class_getSuperclass(_logos_class$_ungrouped$NSObject); { _logos_register_hook(_logos_class$_ungrouped$NSObject, @selector(sample), (IMP)&_logos_method$_ungrouped$NSObject$sample, (IMP *)&_logos_orig$_ungrouped$NSObject$sample);} /* internal::Function does not implement initializers */;} }
#line 13 "Tweak.x"
```

Any other comments?
-------------------

Outputs of `otool -L` on the result object of using this PR and upstream theos.

`LOGOS_DEFAULT_GENERATOR = MobileSubstrate`

```
	/Library/MobileSubstrate/DynamicLibraries/Sample.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
	/System/Library/Frameworks/Foundation.framework/Foundation (compatibility version 300.0.0, current version 1971.0.0)
	/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation (compatibility version 150.0.0, current version 1971.0.0)
	/Library/Frameworks/CydiaSubstrate.framework/CydiaSubstrate (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1500.65.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.100.3)
```

`LOGOS_DEFAULT_GENERATOR = libhooker`

```
	/Library/MobileSubstrate/DynamicLibraries/Sample.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
	/System/Library/Frameworks/Foundation.framework/Foundation (compatibility version 300.0.0, current version 1971.0.0)
	/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation (compatibility version 150.0.0, current version 1971.0.0)
	@rpath/libhooker.dylib (compatibility version 0.0.0, current version 0.0.0)
	@rpath/libblackjack.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1500.65.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.100.3)
```

`LOGOS_DEFAULT_GENERATOR = internal`

```
	/Library/MobileSubstrate/DynamicLibraries/Sample.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
	/System/Library/Frameworks/Foundation.framework/Foundation (compatibility version 300.0.0, current version 1971.0.0)
	/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation (compatibility version 150.0.0, current version 1971.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1500.65.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.100.3)
```

Where has this been tested?
---------------------------
**Operating System:** macOS

**Platform:** Darwin

**Target Platform:** iPhoneOS

**Toolchain Version:** `clang version 15.0.0`

**SDK Version:** 16.5