### PR TITLE
Fix quote matching

### DIFF
--- a/bin/lib/Logos/Util.pm
+++ b/bin/lib/Logos/Util.pm
@@ -13,7 +13,7 @@ sub quotes {
 	my ($line) = @_;
 	my @quotes = ();
 	# Ignore escaped quotes
-	# Matches anything within TWO of the same quote type (' or ")
+	# Match anything within TWO of the same quote type (' or ")
 	while($line =~ /(?<!\\)(["'])(.*?)(?<!\\)\1/g) {
 		push(@quotes, $-[0], $+[0]);
 	}

--- a/bin/lib/Logos/Util.pm
+++ b/bin/lib/Logos/Util.pm
@@ -12,8 +12,10 @@ sub _defaultErrorHandler {
 sub quotes {
 	my ($line) = @_;
 	my @quotes = ();
-	while($line =~ /(?<!\\)[\"\']/g) {
-		push(@quotes, $-[0]);
+	# Ignore escaped quotes
+	# Matches anything within TWO of the same quote type (' or ")
+	while($line =~ /(?<!\\)(["'])(.*?)(?<!\\)\1/g) {
+		push(@quotes, $-[0], $+[0]);
 	}
 	return @quotes;
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
See title 

Does this close any currently open issues?
------------------------------------------
Appears to resolve #111 

Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
- Previously, we returned quoted lines as instances of either type of quote (" || ') excluding those escaped 
  - This is fine but fails to properly handle the contents of the literal, thus causing issues with other characters, such as } which we use to gauge depth https://github.com/theos/logos/blob/83f47d9b69e8f3bde98b564a0db1c57602b647f9/bin/logos.pl#L231, being treated as if they weren't part of the literal
    - This causes issues in edge cases such as " ' }" or ' " }' where the depth is decremented when it shouldn't be, resulting in the error described in #111.
- To handle this, the quotes subroutine will now consider quotes as the PAIR of the same type of quote and ignore the in-between contents as part of the literal 
  - We still ignore escaped quotes and appear to handle all cases except for those which lack a pair of quotes or end the pair early (e.g., " " "), which is fine as both are invalid in C/ObjC and will need to be properly closed or escaped. 
- The tests in #111 have been tested and now pass with the following change 


**Edit: doesn't look like it properly handles `\`-based multi-line strings:**
```objc
NSString *str = @"Line1 \
                        }Line2";
```

Where has this been tested?
---------------------------
**Operating System:** …

Linux (WSL)

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
