### PR TITLE
Use `__asm__` instead of `asm` in generated C code

### DIFF
--- a/bin/lib/Logos/Generator/MobileSubstrate/Generator.pm
+++ b/bin/lib/Logos/Generator/MobileSubstrate/Generator.pm
@@ -22,7 +22,7 @@ sub preamble {
 sub staticDeclarations {
 	my $self = shift;
 	return join("\n", ($self->SUPER::staticDeclarations(),
-		"asm(\".linker_option \\\"-framework\\\", \\\"CydiaSubstrate\\\"\");",
+		"__asm__(\".linker_option \\\"-framework\\\", \\\"CydiaSubstrate\\\"\");",
 		"" # extra line break for readability
 	));
 }

--- a/bin/lib/Logos/Generator/libhooker/Generator.pm
+++ b/bin/lib/Logos/Generator/libhooker/Generator.pm
@@ -25,8 +25,8 @@ sub preamble {
 sub staticDeclarations {
 	my $self = shift;
 	return join("\n", ($self->SUPER::staticDeclarations(),
-		"asm(\".linker_option \\\"-lhooker\\\"\");",
-		"asm(\".linker_option \\\"-lblackjack\\\"\");",
+		"__asm__(\".linker_option \\\"-lhooker\\\"\");",
+		"__asm__(\".linker_option \\\"-lblackjack\\\"\");",
 		"" # extra line break for readability
 	));
 }


### PR DESCRIPTION
Use __asm__ to support strict language standards such as ISO C99 and improve compiler compatibility.