### PR TITLE
Allow for multi-line %hookf usage

### DIFF
--- a/bin/logos.pl
+++ b/bin/logos.pl
@@ -147,6 +147,7 @@ READLOOP: while(my $line = <FILE>) {
 					$line =~ /^\s*(%new.*?)?\s*([+-])\s*\(\s*(.*?)\s*\)/
 					|| $line =~ /%orig[^;]*$/
 					|| $line =~ /%init[^;]*$/
+					|| $line =~ /%hookf\b[^;]*$/
 				)
 				&& index($line, "{") < $-[0] && index($line, ";") < $-[0]) {
 			if(fallsBetween($-[0], @quotes)) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Allows for multi-line %hookf usage such as
```logos
%hookf(int, MSGetExecutablePath,
		char *buf,
		size_t *size) {
	int ret = %orig(buf, size);
	return ret;
}
```

Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, etc?
-------------------------------------
Without this fix, Logos gives this error while parsing the hookf:
`error: missing closing parenthesis`

Where has this been tested?
---------------------------
**Operating System:** macOS

**Platform:** iOS